### PR TITLE
change server to localhost

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cursor-pool",
-  "version": "1.6.8",
+  "version": "1.7.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cursor-pool",
-      "version": "1.6.8",
+      "version": "1.7.7",
       "dependencies": {
         "@tauri-apps/api": "^2.2.0",
         "@tauri-apps/plugin-dialog": "^2.2.0",

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -84,8 +84,8 @@ impl Default for AppConfig {
     fn default() -> Self {
         Self {
             api: ApiConfig {
-                default_api_url: "https://pool.52ai.org/api".to_string(),
-                config_file_url: "https://cursorpool.oss-cn-guangzhou.aliyuncs.com/config.json".to_string(),
+                default_api_url: "http://127.0.0.1:8080/api".to_string(),//default_api_url: "https://pool.52ai.org/api".to_string(),
+                config_file_url: "http://127.0.0.1:8080/api/inbound/config".to_string(),//config_file_url: "https://cursorpool.oss-cn-guangzhou.aliyuncs.com/config.json".to_string(),
                 cursor_user_id: "user_01000000000000000000000000".to_string(),
                 public_endpoints: vec![
                     "/login".to_string(),

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -104,7 +104,7 @@ export async function getUserInfo(): Promise<UserInfo> {
         if (response.status !== 200) {
             throw new ApiError(response.msg || '链接服务器失败')
         }
-        
+        console.log(response)
         return handleApiResponse(response)
     } catch (error) {
         // 如果已经是ApiError类型，直接抛出

--- a/src/stores/user.ts
+++ b/src/stores/user.ts
@@ -97,6 +97,7 @@ export const useUserStore = defineStore('user', () => {
     try {
       const response = await apiLogin(account, password, spread)
       if (response && response.token) {
+        console.log(response)
         await checkLoginStatus()
         return true
       }

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -102,7 +102,10 @@ const handleChangePassword = async () => {
     message.error('两次输入的新密码不一致')
     return
   }
-  
+  if (!validatePassword(formValue.value.newPassword)) {
+    message.error('密码格式不正确')
+    return
+  }
   passwordChangeLoading.value = true
   try {
     await changePassword(
@@ -239,6 +242,10 @@ watch(() => cursorStore.showSelectFileModal, (newValue, oldValue) => {
   }
 })
 
+const validatePassword = (value: string): boolean => {
+  return /^[a-zA-Z0-9!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?]{6,20}$/.test(value)
+}
+
 // 在组件挂载时检查控制状态
 onMounted(async () => {
   // 初始化状态
@@ -371,7 +378,6 @@ onMounted(async () => {
                 :placeholder="messages[currentLang].settings.currentPassword"
                 maxlength="20"
                 minlength="6"
-                :allow-input="(value) => /^[a-zA-Z0-9]*$/.test(value)"
               />
             </n-form-item>
 
@@ -383,7 +389,6 @@ onMounted(async () => {
                 :placeholder="messages[currentLang].settings.newPassword"
                 maxlength="20"
                 minlength="6"
-                :allow-input="(value) => /^[a-zA-Z0-9]*$/.test(value)"
               />
             </n-form-item>
 
@@ -395,7 +400,6 @@ onMounted(async () => {
                 :placeholder="messages[currentLang].settings.confirmPassword"
                 maxlength="20"
                 minlength="6"
-                :allow-input="(value) => /^[a-zA-Z0-9]*$/.test(value)"
               />
             </n-form-item>
 


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

更新默认 API URL 为 localhost 以进行本地开发，并为更改密码表单添加密码验证。

增强功能：
- 为更改密码表单添加密码验证，以确保其符合特定标准。
- 更新默认 API URL 和配置文件 URL 为 localhost，用于本地开发目的。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Updates the default API URL to localhost for local development and adds password validation to the change password form.

Enhancements:
- Adds password validation to the change password form to ensure it meets certain criteria.
- Updates the default API URL and config file URL to localhost for local development purposes.

</details>