### PR TITLE
chore: update release workflow to copy and rename artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -214,16 +214,22 @@ jobs:
           prerelease: false
           args: --target ${{ matrix.target }} --config src-tauri/tauri.windows.conf.json
           includeUpdaterJson: true
+          withAllChangesets: true
 
       - name: Rename Artifacts
         shell: pwsh
         run: |
+          # 查找并显示原始文件
+          Write-Host "Original files:"
+          Get-ChildItem -Path ".\src-tauri\target\${{ matrix.target }}\release\bundle\msi\*.msi" | ForEach-Object { Write-Host $_.FullName }
+          Get-ChildItem -Path ".\src-tauri\target\${{ matrix.target }}\release\bundle\nsis\*-setup.exe" | ForEach-Object { Write-Host $_.FullName }
+          
           # 重命名MSI文件
           $msiFiles = Get-ChildItem -Path ".\src-tauri\target\${{ matrix.target }}\release\bundle\msi\*.msi"
           foreach ($file in $msiFiles) {
-            $newName = $file.Name -replace ".msi$", "_fixed-webview2.msi"
+            $newName = $file.Name -replace "\.msi$", "_fixed-webview2.msi"
             $newPath = Join-Path -Path $file.Directory.FullName -ChildPath $newName
-            Move-Item -Path $file.FullName -Destination $newPath
+            Copy-Item -Path $file.FullName -Destination $newPath -Force
             Write-Host "Renamed: $($file.Name) -> $newName"
           }
 
@@ -232,7 +238,7 @@ jobs:
           foreach ($file in $exeFiles) {
             $newName = $file.Name -replace "-setup\.exe$", "_fixed-webview2-setup.exe"
             $newPath = Join-Path -Path $file.Directory.FullName -ChildPath $newName
-            Move-Item -Path $file.FullName -Destination $newPath
+            Copy-Item -Path $file.FullName -Destination $newPath -Force
             Write-Host "Renamed: $($file.Name) -> $newName"
           }
 
@@ -242,13 +248,32 @@ jobs:
             if ($file.Name -match "-setup\.exe\.sig$") {
               $newName = $file.Name -replace "-setup\.exe\.sig$", "_fixed-webview2-setup.exe.sig"
               $newPath = Join-Path -Path $file.Directory.FullName -ChildPath $newName
-              Move-Item -Path $file.FullName -Destination $newPath
+              Copy-Item -Path $file.FullName -Destination $newPath -Force
               Write-Host "Renamed: $($file.Name) -> $newName"
             } 
             elseif ($file.Name -match "\.msi\.sig$") {
               $newName = $file.Name -replace "\.msi\.sig$", "_fixed-webview2.msi.sig"
               $newPath = Join-Path -Path $file.Directory.FullName -ChildPath $newName
-              Move-Item -Path $file.FullName -Destination $newPath
+              Copy-Item -Path $file.FullName -Destination $newPath -Force
               Write-Host "Renamed: $($file.Name) -> $newName"
             }
           }
+          
+          # 删除原始文件以避免重复上传
+          Get-ChildItem -Path ".\src-tauri\target\${{ matrix.target }}\release\bundle\msi\*.msi" | Where-Object { -not $_.Name.Contains("_fixed-webview2") } | ForEach-Object { 
+            Write-Host "Removing original file: $($_.FullName)"
+            Remove-Item -Path $_.FullName -Force 
+          }
+          Get-ChildItem -Path ".\src-tauri\target\${{ matrix.target }}\release\bundle\nsis\*-setup.exe" | Where-Object { -not $_.Name.Contains("_fixed-webview2") } | ForEach-Object { 
+            Write-Host "Removing original file: $($_.FullName)"
+            Remove-Item -Path $_.FullName -Force 
+          }
+          Get-ChildItem -Path ".\src-tauri\target\${{ matrix.target }}\release\bundle\*\*.sig" | Where-Object { -not $_.Name.Contains("_fixed-webview2") } | ForEach-Object { 
+            Write-Host "Removing original file: $($_.FullName)"
+            Remove-Item -Path $_.FullName -Force 
+          }
+          
+          # 显示最终文件
+          Write-Host "Final files:"
+          Get-ChildItem -Path ".\src-tauri\target\${{ matrix.target }}\release\bundle\msi\*" | ForEach-Object { Write-Host $_.FullName }
+          Get-ChildItem -Path ".\src-tauri\target\${{ matrix.target }}\release\bundle\nsis\*" | ForEach-Object { Write-Host $_.FullName }


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

更新发布工作流程，复制并重命名包含 WebView2 修复的工件，确保发布过程中正确处理工件。

CI：
- 修改发布工作流程，改进工件命名和处理，增加更详细的日志记录和文件管理步骤

杂项：
- 将工件处理从移动文件更改为复制文件
- 增加文件操作的详细日志记录
- 创建修复后的 webview2 版本后，删除原始文件

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update release workflow to copy and rename artifacts with WebView2 fix, ensuring proper artifact handling during the release process

CI:
- Modify release workflow to improve artifact naming and handling, adding more detailed logging and file management steps

Chores:
- Change artifact handling from moving to copying files
- Add verbose logging for file operations
- Remove original files after creating fixed-webview2 versions

</details>