### PR TITLE
Fix: Return value and concurrent deletion issues in high usage accounts cleanup

### DIFF
--- a/src/stores/history.ts
+++ b/src/stores/history.ts
@@ -232,6 +232,9 @@ export const useHistoryStore = defineStore('history', () => {
 
     clearingHighUsage.value = true
     try {
+      // 保存要删除的账户数量
+      const accountsToDelete = highUsageAccounts.value.length
+      
       // 并发删除高使用量账户
       const deletePromises = highUsageAccounts.value.map((account) =>
         removeHistoryAccount(account.email),
@@ -247,7 +250,7 @@ export const useHistoryStore = defineStore('history', () => {
       })
 
       return {
-        success: highUsageAccounts.value.length,
+        success: accountsToDelete,
       }
     } catch (error) {
       console.error('清理高使用量账户失败:', error)

--- a/src/stores/history.ts
+++ b/src/stores/history.ts
@@ -234,13 +234,11 @@ export const useHistoryStore = defineStore('history', () => {
     try {
       // 保存要删除的账户数量
       const accountsToDelete = highUsageAccounts.value.length
-      
-      // 并发删除高使用量账户
-      const deletePromises = highUsageAccounts.value.map((account) =>
-        removeHistoryAccount(account.email),
-      )
 
-      await Promise.all(deletePromises)
+      // 删除高使用量账户
+      for (const account of highUsageAccounts.value) {
+        await removeHistoryAccount(account.email)
+      }
 
       // 更新账户列表
       accounts.value = accounts.value.filter((account) => {


### PR DESCRIPTION
After clear highUsageAccounts, it always return 0. Saving the highUsageAccounts value before clean

好的，这是将给定的 pull request 总结翻译成中文的结果：

## Sourcery 总结

Bug 修复:
- 确保返回值反映了在清除之前要删除的帐户数量，防止返回不正确的零值。

<details>
<summary>Original summary in English</summary>

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

修复清理高用量账户时的并发和返回值问题

Bug 修复:
- 确保返回值正确反映清理前要删除的账户数量
- 修改账户删除流程，以更可靠地处理并发删除

增强功能:
- 改进高用量账户的错误处理和账户删除机制

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix concurrency and return value issues when clearing high usage accounts

Bug Fixes:
- Ensure the return value correctly reflects the number of accounts to be deleted before clearing
- Modify account deletion process to handle concurrent deletions more reliably

Enhancements:
- Improve error handling and account deletion mechanism for high usage accounts

</details>

</details>