### PR TITLE
feat(api): add SSL certificate verification configuration to ApiClient

### DIFF
--- a/src-tauri/src/api/client.rs
+++ b/src-tauri/src/api/client.rs
@@ -20,9 +20,21 @@ pub struct ApiClient {
 impl ApiClient {
     /// 创建 API 客户端实例
     pub fn new(app_handle: Option<AppHandle>) -> Self {
+        // 从配置中读取是否验证SSL证书
+        let verify_ssl = config::CONFIG.read().unwrap().api.verify_ssl;
+        
+        // 创建客户端构建器并根据配置决定是否验证证书
+        let mut client_builder = Client::builder()
+            .timeout(config::get_request_timeout());
+            
+        // 如果不验证SSL证书，添加跳过验证选项
+        if !verify_ssl {
+            client_builder = client_builder.danger_accept_invalid_certs(true);
+        }
+        
+        // 构建HTTP客户端
         let client = Arc::new(
-            Client::builder()
-                .timeout(config::get_request_timeout())
+            client_builder
                 .build()
                 .expect("Failed to create HTTP client"),
         );

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -18,6 +18,8 @@ pub struct ApiConfig {
     pub public_endpoints: Vec<String>,
     // API请求超时时间(秒)
     pub request_timeout: u64,
+    // 是否验证SSL证书
+    pub verify_ssl: bool,
 }
 
 // 路径配置结构
@@ -116,6 +118,7 @@ impl Default for AppConfig {
                     "/api/usage".to_string(),
                 ],
                 request_timeout: 10,
+                verify_ssl: false,
             },
             paths: PathConfig {
                 windows: WindowsPaths {
@@ -284,4 +287,9 @@ pub fn get_db_key(key_name: &str) -> String {
         "lang" => config.db_keys.lang_key.clone(),
         _ => panic!("Unknown key name: {}", key_name),
     }
+}
+
+// 获取是否验证SSL证书的配置
+pub fn get_verify_ssl() -> bool {
+    CONFIG.read().unwrap().api.verify_ssl
 }


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

添加配置选项以控制 API 客户端的 SSL 证书验证

新特性：
- 引入一个配置选项，用于启用或禁用 API 请求的 SSL 证书验证

增强功能：
- 修改 `ApiClient` 以遵循 SSL 验证配置
- 增加处理 SSL 证书验证的灵活性

杂项：
- 更新默认配置，将 SSL 验证设置为 false

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configuration option to control SSL certificate verification for API client

New Features:
- Introduce a configuration option to enable or disable SSL certificate verification for API requests

Enhancements:
- Modify ApiClient to respect SSL verification configuration
- Add flexibility in handling SSL certificate validation

Chores:
- Update default configuration to set SSL verification to false

</details>